### PR TITLE
Replaced dls-controls with DiamondLightSource

### DIFF
--- a/.gitremotes
+++ b/.gitremotes
@@ -1,2 +1,2 @@
-dls-controls git@github.com:dls-controls/vds-gen.git
+DiamondLightSource git@github.com:DiamondLightSource/vds-gen.git
 gitolite ssh://dascgitolite@dasc-git.diamond.ac.uk/controls/python/vds-gen

--- a/README.rst
+++ b/README.rst
@@ -6,12 +6,12 @@ A command line tool for creating virtual dataset HDF5 files from a set of HDF5 f
 
     |Build Status|  |Coverage Status|  |Code Health|  |PyPI|
 
-.. |Build Status| image:: https://api.travis-ci.org/dls-controls/vds-gen.svg
-    :target: https://travis-ci.org/dls-controls/vds-gen
-.. |Coverage Status| image:: https://coveralls.io/repos/github/dls-controls/vds-gen/badge.svg?branch=master
-    :target: https://coveralls.io/github/dls-controls/vds-gen?branch=master
-.. |Code Health| image:: https://landscape.io/github/dls-controls/vds-gen/master/landscape.svg?style=flat
-    :target: https://landscape.io/github/dls-controls/vds-gen/master
+.. |Build Status| image:: https://api.travis-ci.org/DiamondLightSource/vds-gen.svg
+    :target: https://travis-ci.org/DiamondLightSource/vds-gen
+.. |Coverage Status| image:: https://coveralls.io/repos/github/DiamondLightSource/vds-gen/badge.svg?branch=master
+    :target: https://coveralls.io/github/DiamondLightSource/vds-gen?branch=master
+.. |Code Health| image:: https://landscape.io/github/DiamondLightSource/vds-gen/master/landscape.svg?style=flat
+    :target: https://landscape.io/github/DiamondLightSource/vds-gen/master
 .. |PyPI| image:: https://img.shields.io/pypi/v/vdsgen.svg
     :target: https://pypi.python.org/pypi/vdsgen/
     :alt: Latest PyPI version


### PR DESCRIPTION
Repository was automatically transferred from `dls-controls/vdsgen` using https://gitlab.diamond.ac.uk/github/github-scripts